### PR TITLE
Bug fix - is_nested() raises AttributeError

### DIFF
--- a/drf_nested_forms/utils.py
+++ b/drf_nested_forms/utils.py
@@ -72,8 +72,23 @@ class NestedFormBaseClass(UtilityMixin):
         conditions = [is_mapping]
 
         #############################################################
-        if not is_mapping and raise_exception:
-            raise ValueError('`data` is not a map type')
+        # If "is_mapping" is False, code "self._initial_data.keys()" 
+        # will raise an AttributeError and in result request method 
+        # will receive an empty QueryDict, instead of parsed data
+        # (even if the data could be parsed by another parser in DRF
+        # DEFAULT_PARSER_CLASSES!)
+        #
+        # Example: exception is raised for self._initial_data == [
+        #   {
+        #       "field1": 1, 
+        #       "field2": 2
+        #   }
+        # ]
+        # 
+        if not is_mapping:
+            if raise_exception:
+                raise ValueError('`data` is not a map type')
+            return False
         #############################################################
 
         matched_keys = [

--- a/tests/test_nested_form.py
+++ b/tests/test_nested_form.py
@@ -288,3 +288,28 @@ class NestedFormTestCase(unittest.TestCase):
         with self.assertRaises(ParseError):
             form = NestedForm(data)
             form.is_nested(raise_exception=True)
+
+    def test_data_10(self):
+        """
+        test that will verify if "is_nested" is not throwing 
+        unexpected exceptions when given a list in standard
+        JSON format (used to throw AttributeError)
+        """
+        data = [
+            {
+                "field1": 1,
+                "field2": 2
+            },
+        ]
+
+        form = NestedForm(data)
+        try:
+            form.is_nested()
+            # Whatever is returned from is_nested() is not relevant
+            # for this test. In the future the library might start
+            # handling JSON lists as valid input, therefore the test
+            # should not expect is_nested() to return False
+        except Exception as e:
+            self.fail(
+                f"NestedForm failed with an unhandled exception ({e})"
+            )


### PR DESCRIPTION
```is_nested()``` raises an unhandled AttributeError exception for input that is not an instance of Mapping.

This pull request prevents the exception by returning "False" earlier on, and letting other parsers handle this type of input (since this library does not handle such inputs - at least for now).